### PR TITLE
Improve UI for long lists of co-authors

### DIFF
--- a/src/main/java/hu/hawser/coauthorplugin/AuthorListPopup/CoAuthorListPopup.java
+++ b/src/main/java/hu/hawser/coauthorplugin/AuthorListPopup/CoAuthorListPopup.java
@@ -8,11 +8,14 @@ import hu.hawser.coauthorplugin.AuthorListPopup.elements.AuthorElement;
 import hu.hawser.coauthorplugin.AuthorListPopup.elements.AuthorListElement;
 import hu.hawser.coauthorplugin.AuthorListPopup.elements.MoreOptionsElement;
 import hu.hawser.coauthorplugin.CoAuthorSelector;
+import icons.Icons;
 import org.jetbrains.annotations.NotNull;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
 
 public class CoAuthorListPopup extends BaseListPopupStep<AuthorListElement> {
 
@@ -26,7 +29,12 @@ public class CoAuthorListPopup extends BaseListPopupStep<AuthorListElement> {
     private final ListSelectionHandler<String> selectionHandler;
 
     public CoAuthorListPopup(@NotNull Project project, @NotNull String title, @NotNull List<String> authorList, @NotNull ListSelectionHandler<String> selectionHandler) {
-        super(title, Stream.concat(authorList.stream().map(AuthorElement::new), Stream.of(new MoreOptionsElement())).collect(Collectors.toList()));
+        super(title, Stream.concat(
+                Stream.of(new MoreOptionsElement()),
+                authorList.stream().map(AuthorElement::new)
+            ).collect(toList()),
+            singletonList(Icons.USERS)
+        );
         this.project = project;
         this.authorList = authorList;
         this.selectionHandler = selectionHandler;

--- a/src/main/java/hu/hawser/coauthorplugin/CoAuthorSelector.java
+++ b/src/main/java/hu/hawser/coauthorplugin/CoAuthorSelector.java
@@ -4,12 +4,12 @@ import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.*;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.DialogWrapper;
+import com.intellij.ui.components.JBScrollPane;
 import com.intellij.ui.table.JBTable;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import javax.swing.table.TableCellRenderer;
-import javax.swing.table.TableColumn;
 import javax.swing.table.TableColumnModel;
 import java.awt.*;
 import java.util.List;
@@ -35,7 +35,8 @@ public class CoAuthorSelector extends DialogWrapper {
         mainPanel.setLayout(new BorderLayout());
 
         JBTable table = createTable();
-        mainPanel.add(table, BorderLayout.CENTER);
+        JScrollPane scrollPane = new JBScrollPane(table);
+        mainPanel.add(scrollPane, BorderLayout.CENTER);
         mainPanel.add(createToolbar(table), BorderLayout.SOUTH);
 
         tableModel.addTableModelListener(e -> pack());
@@ -45,10 +46,16 @@ public class CoAuthorSelector extends DialogWrapper {
 
 
     private JBTable createTable() {
-        JBTable table = new JBTable(tableModel);
+        JBTable table = new JBTable(tableModel) {
+            // https://stackoverflow.com/a/37343900/14379
+            @Override
+            public Dimension getPreferredScrollableViewportSize() {
+                return new Dimension(getPreferredSize().width, getRowHeight() * getRowCount());
+            }
+        };
 
         resizeColumnWidthToFitContent(table);
-        preventResizingFirstColumn(table);
+        table.setShowColumns(false);
         table.setAutoResizeMode(JTable.AUTO_RESIZE_LAST_COLUMN);
 
         return table;
@@ -77,12 +84,6 @@ public class CoAuthorSelector extends DialogWrapper {
         panel.add(toolbar.getComponent());
 
         return panel;
-    }
-
-
-    private void preventResizingFirstColumn(JBTable table) {
-        TableColumn firstColumn = table.getColumnModel().getColumn(0);
-        firstColumn.setMaxWidth(firstColumn.getWidth());
     }
 
 


### PR DESCRIPTION
The table for choosing multiple co-authors is given a scroll bar. Previously any co-authors at the end of a long list were invisible and not selectable.

Also "More Options" is now at the top of the pop-up, with the keyboard focus and an icon, instead of down the bottom, perhaps requiring scrolling. 
